### PR TITLE
Add clusterserviceversions permissions.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -89,3 +89,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/gpuaddon_controller.go
+++ b/controllers/gpuaddon_controller.go
@@ -53,6 +53,7 @@ var resouceOrderedReconcilers = &[]ResourceReconciler{
 //+kubebuilder:rbac:groups=nvidia.addons.rh-ecosystem-edge.io,namespace=system,resources=gpuaddons/finalizers,verbs=update
 //+kubebuilder:rbac:groups=nvidia.com,resources=clusterpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=nfd.openshift.io,namespace=system,resources=nodefeaturediscoveries,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=operators.coreos.com,namespace=system,resources=clusterserviceversions,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This PR adds read permissions on clusterserviceversions.operators.coreos.com resources to the GPUAddon controller, in order to be able to fetch ALM examples from the respective CSVs installed on the cluster.