### PR TITLE
Enhance Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,25 @@
 # Build the manager binary
 FROM golang:1.17 as builder
+WORKDIR /opt/app-root/src
 
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+# Copy the Makefile, Go Modules manifests and vendored dependencies
+COPY --chown=1001:0 Makefile Makefile
+COPY --chown=1001:0 go.mod go.mod
+COPY --chown=1001:0 go.sum go.sum
+COPY --chown=1001:0 vendor vendor
 
 # Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
-COPY internal/ internal/
+COPY --chown=1001:0 main.go main.go
+COPY --chown=1001:0 api/ api/
+COPY --chown=1001:0 controllers/ controllers/
+COPY --chown=1001:0 internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN go build -ldflags="-s -w" -o bin/manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
-USER 65532:65532
+# Use UBI8 Micro as minimal base image to package the manager binary
+# Refer to https://www.redhat.com/en/blog/introduction-ubi-micro for more details
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.5
+COPY --from=builder /opt/app-root/src/bin/manager /usr/local/bin/manager
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/local/bin/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,9 +27,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --leader-elect
         image: controller:latest
         name: manager


### PR DESCRIPTION
This PR enhances the operator's container image. The changes include:

- base container image on ubi-micro 8.5
- do not specify OS and architecture when building the operator binary
- leverage go vendoring, instead of downloading modules