### PR TITLE
Create GPUAddon CR on boot if not exists

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -18,7 +18,7 @@ type config struct {
 	NfdCsvNamespace   string `envconfig:"NFD_CSV_NAMESPACE" default:"redhat-nvidia-gpu-addon"`
 	GpuCsvPrefix      string `envconfig:"GPU_CSV_PREFIX" default:"gpu-operator-certified"`
 	GpuCsvNamespace   string `envconfig:"GPU_CSV_NAMESPACE" default:"redhat-nvidia-gpu-addon"`
-	AddonNamespace    string `envconfig:"ADDON_NAMESPACE" default:"redhat-nvidia-gpu-addon"`
+	AddonNamespace    string `envconfig:"WATCH_NAMESPACE" default:"redhat-nvidia-gpu-addon"`
 	AddonID           string `envconfig:"ADDON_ID" default:"nvidia-gpu-addon"`
 	AddonLabel        string `envconfig:"ADDON_LABEL" default:"api.openshift.com/addon-nvidia-gpu-operator"`
 	ClusterPolicyName string `envconfig:"CLUSTER_POLICY_NAME" default:"ocp-gpu-addon"`

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	addonv1alpha1 "github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/api/v1alpha1"
+	"github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/internal/common"
+	"github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/internal/version"
+)
+
+func TestMain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Main Suite")
+}
+
+var _ = Describe("Jumpstart tests", func() {
+	common.ProcessConfig()
+	It("Should create GPUAddon CR if not exists", func() {
+		c := newTestClientWith()
+		Expect(jumpstartAddon(c)).ShouldNot(HaveOccurred())
+		g := &addonv1alpha1.GPUAddon{}
+		Expect(c.Get(context.TODO(), types.NamespacedName{
+			Namespace: common.GlobalConfig.AddonNamespace,
+			Name:      common.GlobalConfig.AddonID,
+		}, g)).ShouldNot(HaveOccurred())
+	})
+	It("Should not fail if a GPUAddon CR already Exists", func() {
+		g := &addonv1alpha1.GPUAddon{}
+		g.Name = common.GlobalConfig.AddonID
+		g.Namespace = common.GlobalConfig.AddonNamespace
+		c := newTestClientWith(g)
+		Expect(jumpstartAddon(c)).ShouldNot(HaveOccurred())
+		Expect(c.Get(context.TODO(), types.NamespacedName{
+			Namespace: common.GlobalConfig.AddonNamespace,
+			Name:      common.GlobalConfig.AddonID,
+		}, g)).ShouldNot(HaveOccurred())
+		versionLabel := fmt.Sprintf("%v-version", common.GlobalConfig.AddonLabel)
+		Expect(g.ObjectMeta.Labels[versionLabel]).To(Equal(version.Version()))
+	})
+
+})
+
+func newTestClientWith(objs ...runtime.Object) client.Client {
+	s := clientgoscheme.Scheme
+	Expect(addonv1alpha1.AddToScheme(s)).ShouldNot(HaveOccurred())
+	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+}


### PR DESCRIPTION
This PR Adds a jumpstart function that will remove the need for an "init container" for the addon.

currently it will check if a CR already exists. If not it will create one.

/hold