### PR TITLE
Fix subscription reconciler not fetching any existing subcription

### DIFF
--- a/controllers/subscription_resource_reconciler.go
+++ b/controllers/subscription_resource_reconciler.go
@@ -56,7 +56,7 @@ func (r *SubscriptionResourceReconciler) Reconcile(
 
 	err := client.Get(ctx, types.NamespacedName{
 		Namespace: gpuAddon.Namespace,
-		Name:      common.GlobalConfig.NfdCrName,
+		Name:      subscriptionName,
 	}, existingSubscription)
 
 	exists := !k8serrors.IsNotFound(err)
@@ -89,7 +89,7 @@ func (r *SubscriptionResourceReconciler) Reconcile(
 
 	logger.Info("Subscription reconciled successfully",
 		"name", s.Name,
-		"namespace", gpuAddon.Namespace,
+		"namespace", s.Namespace,
 		"result", res)
 
 	return conditions, nil


### PR DESCRIPTION
This PR fixes the SubscriptionResourceReconciler not using the correct subscription name when trying to fetch the existing subscription (if any), resulting in not being able to leverage any status updates.