### PR TITLE
Enable prometheus integration

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -18,3 +18,26 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics
+  namespace: system
+spec:
+  groups:
+    - name: NVIDIA GPUAddon GPU Operator Subscription Installation Pending
+      rules:
+        - alert: NVIDIAGPUAddonGPUOperatorSubscriptionInstallationPending
+          expr: |
+             nvidia_gpuaddon_gpu_operator_subscription_installed < 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: The NVIDIA GPUAddon GPU Operator installation is still pending after 10 minutes
+            message: |
+              The NVIDIA GPUAddon GPU Operator installation is still pending after 10 minutes, please
+              check the operator Subscription and ClusterServiceVersion for more details.

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	SubscriptionInstalled = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "nvidia_gpuaddon_gpu_operator_subscription_installed",
+			Help: "Reports whether the NVIDIA GPUAddon GPU Operator OLM Subscription is installed",
+		},
+		[]string{"current_csv", "installed_csv"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		SubscriptionInstalled,
+	)
+}

--- a/controllers/subscription_resource_reconciler.go
+++ b/controllers/subscription_resource_reconciler.go
@@ -74,6 +74,12 @@ func (r *SubscriptionResourceReconciler) Reconcile(
 
 	if exists {
 		s = existingSubscription
+
+		if s.Status.InstalledCSV != "" {
+			SubscriptionInstalled.WithLabelValues(s.Status.CurrentCSV, s.Status.InstalledCSV).Set(1)
+		} else {
+			SubscriptionInstalled.WithLabelValues("", "").Set(0)
+		}
 	}
 
 	res, err := controllerutil.CreateOrPatch(context.TODO(), client, s, func() error {


### PR DESCRIPTION
This PR enables [Prometheus](https://prometheus.io/) integration for the NVIDIA GPUAddon Operator and specifically with the [prometheus operator](https://github.com/prometheus-operator/prometheus-operator).  

### Changes

The following changes are included:

- enable the Prometheus ServiceMonitor for the GPUAddon Operator metrics service
- add and register a custom metric for the managed GPU Operator Subscription, which reports whether the latter is installed or not
- add a [Prometheus alerting rule](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/), set as a warning and triggered after 10 minutes of the GPU Operator Subscription installation pending (based on the previously mentioned custom metric)

### Context

The controller-runtime already includes operator specific [metrics](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/internal/controller/metrics/metrics.go). KubeBuilder also provides us with an [easy way](https://book.kubebuilder.io/reference/metrics.html#publishing-additional-metrics) to expose additional metrics to the controller-runtime default metrics.

In this respect, we would like to expose additional NVIDIA GPUAddon Operator metrics, which would be used for alerting purposes at this first step.

#### Alert types 

We consider 2 types of alerts:

- the alerts related directly on the NVIDIA GPUAddon Operator
- the alerts included via the NVIDIA GPU Operator

##### NVIDIA GPUAddon Operator Alerts

The NVIDIA GPUAddon Operator manages the NVIDIA GPU Operator, the ClusterPolicy CR. Given that the NVIDIA GPU operator includes its own alerts, the alerts to be added by the NVIDIA GPUAddon Operator are relevant (at this point) to the NVIDIA GPU Operator's Subscription. 

This is why we need a custom/additional metric that is going to help in this regard to create a useful alert on whether the Subscription has been successfully installed or not.

##### NVIDIA GPU Operator Alerts

The alerts defined by the NVIDIA GPU Operator are reference [here](https://github.com/NVIDIA/gpu-operator/blob/master/assets/state-operator-metrics/0400_prometheus_rule_openshift.yaml). The most important of the alerts are:

- `GPUOperatorReconciliationFailed` - _GPU Operator could not reconcile resources for 1h_
- `GPUOperatorReconciliationFailedNfdLabelsMissing` - _GPU Operator reconciliation loop failed for more than 30min and NFD labels missing_