### PR TITLE
Bump Go from 1.17 to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 WORKDIR /opt/app-root/src
 
 # Copy the Makefile, Go Modules manifests and vendored dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator
 
-go 1.17
+go 1.18
 
 require (
 	github.com/NVIDIA/gpu-operator v1.10.0


### PR DESCRIPTION
This PR bumps Golang from 1.17 to 1.18, as Go 1.18 includes various performance improvements and language features.

> https://tip.golang.org/doc/go1.18