### PR TITLE
Fix NFD operand image not being based on OSE

### DIFF
--- a/controllers/nfd_resource_reconciler.go
+++ b/controllers/nfd_resource_reconciler.go
@@ -95,7 +95,7 @@ func (r *NFDResourceReconciler) setDesiredNFD(
 	nfd.Spec = nfdv1.NodeFeatureDiscoverySpec{}
 
 	nfd.Spec.Operand = nfdv1.OperandSpec{
-		Image:           fmt.Sprintf("quay.io/openshift/origin-node-feature-discovery:%s", ocpVersion),
+		Image:           fmt.Sprintf("registry.redhat.io/openshift4/ose-node-feature-discovery:v%s", ocpVersion),
 		ImagePullPolicy: "Always",
 		ServicePort:     12000,
 	}


### PR DESCRIPTION
This PR replaces the NFD operand origin image with the [OSE based one](https://catalog.redhat.com/software/containers/openshift4/ose-node-feature-discovery/5d96f167d70cc50ebeaadb9c).