### PR TITLE
Update bundle template files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= 99.0.0
 
 VERSION_PACKAGE = "github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/internal/version"
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,9 @@ spec:
       containers:
       - args:
         - --leader-elect
+        env:
+        - name: RELATED_IMAGE_CONSOLE_PLUGIN
+          value: quay.io/edge-infrastructure/console-plugin-nvidia-gpu:latest
         image: controller:latest
         name: manager
         securityContext:

--- a/config/manifests/bases/nvidia-gpu-addon-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nvidia-gpu-addon-operator.clusterserviceversion.yaml
@@ -4,8 +4,14 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    certified: "false"
+    olm.skipRange: '>=0.0.0 <99.0.0'
     operatorframework.io/suggested-namespace: redhat-nvidia-gpu-addon
-  name: nvidia-gpu-addon-operator.v0.0.1
+    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator
+    support: Red Hat
+  name: nvidia-gpu-addon-operator.v99.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -46,10 +52,8 @@ spec:
   maintainers:
   - email: openshift-nvidia@redhat.com
     name: Redhat ecosystem nvidia team
-  - email: sdayan@redhat.com
-    name: Sagi Dayan
-  maturity: alpha
+  maturity: beta
   provider:
     name: RedHat
     url: https://redhat.com
-  version: 0.0.1
+  version: 99.0.0

--- a/config/manifests/patches/related_images.yaml
+++ b/config/manifests/patches/related_images.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: nvidia-gpu-addon-operator.v0.0.1
+  name: nvidia-gpu-addon-operator.v99.0.0
   namespace: placeholder
 spec:
   relatedImages:

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -23,7 +23,7 @@ type config struct {
 	AddonLabel         string `envconfig:"ADDON_LABEL" default:"api.openshift.com/addon-nvidia-gpu-addon"`
 	ClusterPolicyName  string `envconfig:"CLUSTER_POLICY_NAME" default:"ocp-gpu-addon"`
 	NfdCrName          string `envconfig:"NFD_CR_NAME" default:"ocp-gpu-addon"`
-	ConsolePluginImage string `envconfig:"CONSOLE_PLUGIN_IMAGE" default:"quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:248080b389af7249389d6d29c6683127b92932f2d6439f7474b3886b08773860"`
+	ConsolePluginImage string `envconfig:"RELATED_IMAGE_CONSOLE_PLUGIN" default:"quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:248080b389af7249389d6d29c6683127b92932f2d6439f7474b3886b08773860"`
 }
 
 var GlobalConfig config


### PR DESCRIPTION
This change updates the template files used to generate the bundle:

- Add a few annotations directly in the CSV. They are expected by the
  toolchain downstream, so just keeping u/s and d/S in sync.

- Set the version to `99.0.0` in `main` branch to ensure that it is
  always a higher version than any release branch. This should be
  overridden in release branches.

- Use `RELATED_IMAGE_` prefix for container images environment variables
  passed to the controller container. This is used by [OpenShift Build
  Service](https://osbs.readthedocs.io/en/osbs_ocp3/index.html), aka
  OSBS, to build the [operator
  manifest](https://osbs.readthedocs.io/en/osbs_ocp3/users.html#operator-manifests).
  Again, this is useful for downstream automation.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>