### PR TITLE
Address low and moderate security concerns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7 as builder
 WORKDIR /opt/app-root/src
 
 # Copy the Makefile, Go Modules manifests and vendored dependencies
@@ -21,5 +21,6 @@ RUN make build
 # Refer to https://www.redhat.com/en/blog/introduction-ubi-micro for more details
 FROM registry.access.redhat.com/ubi8/ubi-micro:8.5
 COPY --from=builder /opt/app-root/src/bin/manager /usr/local/bin/manager
+USER 1001
 
 ENTRYPOINT ["/usr/local/bin/manager"]

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -27,6 +27,10 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,8 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/consoleplugin_resource_reconciler.go
+++ b/controllers/consoleplugin_resource_reconciler.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -363,6 +364,11 @@ func (r *ConsolePluginResourceReconciler) setDesiredConsolePluginDeployment(
 			ContainerPort: 9443,
 			Protocol:      corev1.ProtocolTCP,
 		},
+	}
+
+	consolePluginContainer.SecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: pointer.Bool(true),
+		RunAsNonRoot:             pointer.Bool(true),
 	}
 	consolePluginContainer.VolumeMounts = []corev1.VolumeMount{
 		{


### PR DESCRIPTION
Use Red Hat UBI Go Toolset image as builder image in the Dockerfile.
This ensure that all images benefit from updates by Red Hat.

Provide explicit security context for all containers, more precisely:

- `allowPrivilegeEscalation: false`
- `readOnlyRootFilesystem: true`
- `runAsNonRoot: true`

There's an exception though. The console plugin pod cannot have a
read-only root filesystem, because it creates temporary files.

Add the `USER` statement to the Dockerfile to ensure a non root user
will run the application. Here `1001` is the default for UBI images.

Related to PLMPGM-829.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>