### PR TITLE
Fix ClusterPolicy CRs not being watched by the add-on controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,10 +170,7 @@ func watchForOwnClusterPoliciesWhenAvailable(c controller.Controller) error {
 
 	err := c.Watch(
 		&source.Kind{Type: &gpuv1.ClusterPolicy{}},
-		&handler.EnqueueRequestForOwner{
-			OwnerType:    &nvidiav1alpha1.GPUAddon{},
-			IsController: true,
-		})
+		&handler.EnqueueRequestForObject{})
 
 	if err != nil {
 		return fmt.Errorf("unable to watch for owned ClusterPolicy CRs: %w", err)


### PR DESCRIPTION
This PR fixes the ClusterPolicy CR deployed by the add-on controller not being watched. This issue was that the watch was defined to enqueue add-on controller owned ClusterPolicy CRs, although we cannot and do not add ownership to the ClusterPolicy CR managed by the add-on controller. 

> According to the Kubernetes [docs](https://kubernetes.io/docs/concepts/architecture/garbage-collection/#owners-and-dependents) and the [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/controller/controllerutil/controllerutil.go#L148), cluster-scoped dependents can only have cluster-scoped owners. That is the reason for the namespaced GPUAddon CR not being able to be an owner of a cluster-scoped ClusterPolicy CR.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>