### PR TITLE
Added hack script to generate bundles for MTB.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
+# managed-tenants-bundle prev-version use pv=<version> to override
+pv ?= null
+# managed-tenants-bundle channel use c=<alpha/beta/stable> to override
+c ?= alpha
+
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
@@ -49,7 +54,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/sdayan/t-o:latest
+IMG ?= quay.io/edge-infrastructure/nvidia-gpu-addon-operator:1.0.0
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
@@ -201,6 +206,10 @@ bundle-build: ## Build the bundle image.
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+
+.PHONY: mtb-bundle
+mtb-bundle: bundle
+	./hack/create-managed-tenants-bundle.py -mP $(mP) -v $(v) -pv $(pv) -c $(c)
 
 .PHONY: opm
 OPM = ./bin/opm

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/sdayan/t-o
-  newTag: latest
+  newName: quay.io/edge-infrastructure/nvidia-gpu-addon-operator
+  newTag: 1.0.0

--- a/config/manifests/bases/nvidia-gpu-addon-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nvidia-gpu-addon-operator.clusterserviceversion.yaml
@@ -22,8 +22,9 @@ spec:
       kind: GPUAddon
       name: gpuaddons.nvidia.addons.rh-ecosystem-edge.io
       version: v1alpha1
-  description: A managed redhat ocm addon for deploying nVidia gpu-operator with ease
-  displayName: NVIDIA GPU Addon
+  description: A managed Red Hat OCM add-on for deploying NVIDIA GPU Operator with
+    ease
+  displayName: NVIDIA GPU Add-on
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAB2lBMVEUAAAD///8EBAN3uQACAgIAAAQJDQUCAgB1tgAHCQf+/v5Ufg5Hagxxqwt+xgJ3uAB9wwB4vQBRUVEeLA3e3t5nZ2coKCgODg4FBwZ9wwR6wAJ4vADz8/MbGxt5tw1vpw1/wgoOFwkLDwh9xQH5+fny8vLw8PDFxcWysrKFhYVvb282NjYyMjIqKioXFxdikxRYgxNCYxJQdhFqoQ9xrg16ugxyqgyAxQkEBQj7+/v29vbIyMhjY2NbW1tHR0cvLy8kJCQdHR0ZGRlKbxJ8uhFNcxFVgBAxSBBgkg93tQ50sA4qPg4XIg18vwsbKQsSGgsLCwsMEwqCyQeByQFztADPz8+/v7+6urqWlpZra2tKSkogICASEhJmmRE8XBA5VRA2UBBonA9biA9GaQ4sQg4jMw4mOQ0aJw2GzgsUHgttpAqJ0Ql/wQWG0AJ8vwF0uQCtra2jo6OQkJB9fX1VVVVCQkI9PT0iIiIUFBRSfBNgjhA7WRBGZw+GywmFzgaAyASBxQN2twDb29u2traenp6Kiop+fn53d3dzc3NyqRV4sxM/YBNAXRElNhBjlQ+IzA00TQ16vgxJbgp6vAl4tgJ3vgDs7Ozn5+fa2trS0tJCXRY6VBV6thSL1gf4nFdFAAAD80lEQVRYw+zSOXPaQBgG4He0LJJmbGRGDUIzuvgBQiAEPfcdwC33DTbUtmOwSyc+4iRucvzXRImLFJmRShc8xXbfu+9+szg4OHjjAsH/iFD49q7rqM6xc/wPtWyBhS8sC94ObWRCZDksh1+RzmcEfI0DoPrjylEkSTgViMs9udjYTwMG4Gf51Z1BM81ioRwit+QvgYsdUQZeKFr3ladyKXvVr+pAM5uKcmRLXFzoCIxn+0i/8lSaBMHnfi7qowfQuZnm3PuFPwGs13zD3NlViozY/z4YD6/TCQORbPr2q78GLB0ou5IO40pd5AxQZnJ83m2y9Ju2JYKfgEhWC18aEIfrZLURHwQC0B87ySZwHxX8BNDWB1KfQfyxT2TA24uPQMt8yTWA3obz8wQGlhTN06Z900MkuJLrYu3u5LkK9LTtGRF8NEDLeSnXYLUdHUFVlpPqTa4IamlhJZ464biY1w4CKGrROOW7uwLlV+Q02lanCF6cbSoPVLzUfPwDll5I9T6WyXWhZre1yjiI6VCSzCWY3+FKaAwGHngzpEygx6+V6Uzk6TJR7yhWxJ1bFgTPJ7gMc58aUCq+n+qNT6Pn8y/xOcCiZZVjnJ+AAPhEuj0SKZ9bL9ZpNS9SgM6z9p5w3jt43cMvecfWBhm7dtfEpfhYMDBYpFd7mDZIAxPCFKgBhB0hkWbE2wVMyqycfhOMEiebSzFz5IMTEjw7E87UFj4GVR7GXqaSkoIcISEc/I38/PwhOTUMRBrADgwK09zgYGUBqbwcARiQyp3Eyk6kC4BloqtbJTcaSHIHShALWFmBSRuCWBGC+AtDMAAGIpAAc9mBiB0sCLSXHUSygxSxEIoE7IKEgbhopKgogC96x04QCMMw/H0cG6f0cEmBHaLc7FFQzApoTLwtQgWUWo26glx2mzGkyoHM1PPMO/NrnSH8e2QAiRsZ8S3ZuJoW5Udg5moGoMRLN2gAnkcUctueJ1gADsdtlZ2AgmSYoaDZBXwRctcwy6HN3XX/wfnTnA7Q5x0S0Gku4wHpe7Ql8Mbtu4TqC3qcADGtUl4O3eK0AkZdKH1mU/a6MFQGA7pQGoAVoAuuPYZlLJF2BawVLLjwac6Q8wUax61/CpKQAT6ZX3hFqoqqAFvuf4AzM+NgsoBS/wcSOD7SFzyf6CE9UQK9II1MRvIJm8QSgsLiBZuypsAWKyARElgx5FcLv1N4nFLbB45Sh6+TzsQRtn7bz/B3fS9GQ12bgUE2PKycQbwgXD0SWLwVhpZFq4eHhWloOjLoqGvoRYRGAR2vp2EtpNUaTUpiRAizMAEhKNXpYZNnAUlBCSgFYTIxQTlMMJNGwSgYBdQHAFsKs+/bUkeyAAAAAElFTkSuQmCC
     mediatype: image/png
@@ -47,8 +48,8 @@ spec:
   - addon
   - osd
   links:
-  - name: Nvidia Gpu Addon Operator
-    url: https://nvidia-gpu-addon-operator.domain
+  - name: NVIDIA GPU Add-on operator
+    url: https://github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator
   maintainers:
   - email: openshift-nvidia@redhat.com
     name: Redhat ecosystem nvidia team

--- a/hack/create-managed-tenants-bundle.py
+++ b/hack/create-managed-tenants-bundle.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import yaml
+import pathlib
+from argparse import ArgumentParser
+
+ANNOTATION_PATH = "metadata/annotations.yaml"
+ADDON_PATH = "addons/nvidia-gpu-addon/main"
+MANIFESTS = "manifests"
+ADDON_NAME = "nvidia-gpu-addon-operator"
+CSV_SUFFIX = "clusterserviceversion.yaml"
+
+
+
+def get_csv_file(bundle_path):
+    manifests = os.path.join(bundle_path, MANIFESTS)
+    for file in os.listdir(manifests):
+        if file.endswith(CSV_SUFFIX):
+            return os.path.join(manifests, file)
+
+
+def handle_csv(bundle_path, version, prev_version, channel):
+    print("Handling csv")
+    csv_file = get_csv_file(bundle_path)
+    with open(csv_file, "r") as _f:
+        csv = yaml.safe_load(_f)
+
+    csv["metadata"]["annotations"]["olm.skipRange"] = f">=0.0.1 <{version}"
+    csv["metadata"]["name"] = f"{ADDON_NAME}.{version}"
+    csv["spec"]["version"] = f"{version}"
+    csv["spec"]["maturity"] = f"{channel}"
+    if prev_version != "null":
+        csv["spec"]["replaces"] = f"${ADDON_NAME}.{prev_version}"
+    with open(csv_file, "w") as _f:
+        yaml.dump(csv, _f)
+
+def handle_annotations(bundle_path, channel, namespace):
+    print("Handling annotations")
+    with open(os.path.join(bundle_path, ANNOTATION_PATH), "r") as _f:
+        annotations = yaml.safe_load(_f)
+    annotations["annotations"]["operators.operatorframework.io.bundle.channels.v1"] = channel
+    annotations["annotations"]["operators.operatorframework.io.bundle.channel.default.v1"] = channel
+    annotations["annotations"]["operators.operatorframework.io.bundle.package.v1"] = ADDON_NAME
+    annotations["annotations"]["operatorframework.io/suggested-namespace"] = namespace
+    with open(os.path.join(bundle_path, ANNOTATION_PATH), "w") as _f:
+        yaml.dump(annotations, _f)
+
+
+def create_new_bundle(args):
+    version = args.version
+    addon_path = os.path.join(args.manage_tenants_bundle_path, ADDON_PATH)
+    bundle_path = os.path.join(addon_path, version)
+    if os.path.isdir(bundle_path):
+        replace = False
+        replace = input(f"Bundle version {version} already exists, Do you with to override [y/N]? ").lower()
+        if replace == 'y':
+            print(f"Replacing version {version} with new bundle...")
+            shutil.rmtree(bundle_path)
+        else:
+            print(f"ERROR: bundle version ({version}) already exists. Path: {bundle_path}")
+            exit(1)
+    shutil.copytree("./bundle", bundle_path)
+    shutil.rmtree(os.path.join(bundle_path, "tests"))
+    #copy_tree("./bundle/", bundle_path)
+    #remove_tree(os.path.join(bundle_path, "tests"))
+
+    handle_annotations(bundle_path, args.channel, args.namespace)
+    handle_csv(bundle_path, version, args.prev_version, args.channel)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        __file__,
+        description='adding new bundle version to nvidia-gpu-addon manage-tenants-bundles'
+    )
+    parser.add_argument(
+        '-mP', '--manage-tenants-bundle-path',
+        required=True,
+        help='Path to managed tenants repo on the disk'
+    )
+    parser.add_argument(
+        '-c', '--channel',
+        default="alpha",
+        required=False,
+        help='Channel of addon'
+    )
+    parser.add_argument(
+        '-n', '--namespace',
+        default="redhat-nvidia-gpu-addon",
+        help='Target namespace'
+    )
+    parser.add_argument(
+        '-v', '--version',
+        required=True,
+        help='New addon version'
+    )
+    parser.add_argument(
+        '-pv', '--prev-version',
+        required=False,
+        default="",
+        help='Previous addon version'
+    )
+
+    args = parser.parse_args()
+    create_new_bundle(args)


### PR DESCRIPTION
This PR adds a python script to generate bundles for managed-tenants-bundles.

In addition to the script, I updated some values in the CSV, like displayName and description. 


Example of using the script via make: 

```
make mtb-bundle mP=/path/to/managed-tenants-bundles v=1.0.0 c=beta
```

this will generate a v1.0.0 bundle in the managed-tenants-bundles folder, channel beta.

Flags:
 - **mP** required: path to manage-tenants-bundles folder on local
machine.
 - **v** required: version for the new bundle
 - **c** required: channel. alpha/beta/stable...
 - **pv** optional: previous version
 - **n** optional: namespace. defaults to `redhat-nvidia-gpu-addon`

/cc @fabiendupont @mresvanis 