### PR TITLE
Add Console Plugin NVIDIA GPU resource requests/limits

### DIFF
--- a/controllers/consoleplugin_resource_reconciler.go
+++ b/controllers/consoleplugin_resource_reconciler.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -363,6 +364,16 @@ func (r *ConsolePluginResourceReconciler) setDesiredConsolePluginDeployment(
 		{
 			ContainerPort: 9443,
 			Protocol:      corev1.ProtocolTCP,
+		},
+	}
+	consolePluginContainer.Resources = corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    resource.MustParse("20m"),
+			corev1.ResourceMemory: resource.MustParse("200Mi"),
 		},
 	}
 


### PR DESCRIPTION
This PR adds resource requests/limits to the Console Plugin NVIDIA GPU container. 

> The numbers chosen follow the logic of this [PR](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1962) and they depend on the expected traffic, i.e. requests/sec to be served by NGINX. We assume that these numbers cover our case as well.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>