### PR TITLE
Set NFD operator OLM package dependency instead of an API dependency

### DIFF
--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -1,11 +1,5 @@
 dependencies:
-- type: olm.gvk
+- type: olm.package
   value:
-    group: nfd.openshift.io
-    kind: NodeFeatureDiscovery
-    version: v1
-#- type: olm.gvk
-#  value:
-#    group: console.openshift.io
-#    kind: ConsolePlugin
-#    version: v1alpha1
+    packageName: nfd
+    version: "4.10.0"


### PR DESCRIPTION
This PR sets the [Cluster NFD operator ](https://github.com/openshift/cluster-nfd-operator/tree/release-4.10/manifests/4.10)as an [OLM package dependecy](https://docs.openshift.com/container-platform/4.10/operators/understanding/olm/olm-understanding-dependency-resolution.html#olm-properties_olm-understanding-dependency-resolution), instead of an API dependency.

The specified NFD operator is now included in the add-on's OLM index, in order to work around OLM resolution issues due to missing indices in OpenShift CI and CPaaS clusters.