### PR TITLE
Minor create-managed-tenants-bundle script fixes

### DIFF
--- a/hack/create-managed-tenants-bundle.py
+++ b/hack/create-managed-tenants-bundle.py
@@ -32,7 +32,7 @@ def handle_csv(bundle_path, version, prev_version, channel):
     csv["spec"]["version"] = f"{version}"
     csv["spec"]["maturity"] = f"{channel}"
     if prev_version != "null":
-        csv["spec"]["replaces"] = f"${ADDON_NAME}.{prev_version}"
+        csv["spec"]["replaces"] = f"{ADDON_NAME}.{prev_version}"
     with open(csv_file, "w") as _f:
         yaml.dump(csv, _f)
 

--- a/hack/create-managed-tenants-bundle.py
+++ b/hack/create-managed-tenants-bundle.py
@@ -3,7 +3,6 @@
 import os
 import shutil
 import yaml
-import pathlib
 from argparse import ArgumentParser
 
 ANNOTATION_PATH = "metadata/annotations.yaml"
@@ -11,7 +10,6 @@ ADDON_PATH = "addons/nvidia-gpu-addon/main"
 MANIFESTS = "manifests"
 ADDON_NAME = "nvidia-gpu-addon-operator"
 CSV_SUFFIX = "clusterserviceversion.yaml"
-
 
 
 def get_csv_file(bundle_path):
@@ -35,6 +33,7 @@ def handle_csv(bundle_path, version, prev_version, channel):
         csv["spec"]["replaces"] = f"{ADDON_NAME}.{prev_version}"
     with open(csv_file, "w") as _f:
         yaml.dump(csv, _f)
+
 
 def handle_annotations(bundle_path, channel, namespace):
     print("Handling annotations")
@@ -63,8 +62,6 @@ def create_new_bundle(args):
             exit(1)
     shutil.copytree("./bundle", bundle_path)
     shutil.rmtree(os.path.join(bundle_path, "tests"))
-    #copy_tree("./bundle/", bundle_path)
-    #remove_tree(os.path.join(bundle_path, "tests"))
 
     handle_annotations(bundle_path, args.channel, args.namespace)
     handle_csv(bundle_path, version, args.prev_version, args.channel)


### PR DESCRIPTION
This PR fixes minor `create-managed-tenants-bundle` script issues. Specifically:

- fixes the `replaces` field of the CSV starting with a `$`
- removes an unused import
- adds/removes empty lines according to PEP 8 suggestions

```shell
$ flake8 hack/create-managed-tenants-bundle.py 
hack/create-managed-tenants-bundle.py:6:1: F401 'pathlib' imported but unused
hack/create-managed-tenants-bundle.py:17:1: E303 too many blank lines (3)
hack/create-managed-tenants-bundle.py:39:1: E302 expected 2 blank lines, found 1
``` 

Signed-off-by: Michail Resvanis <mresvani@redhat.com>