### PR TITLE
Allow namespace to run privileged pods

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,9 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
With OpenShift 4.11, the [Pod Security admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) will be enabled and warning will be issued for pods that do not comply. This will generate noise and the fix is fairly simple.

The GPU Operator requires privileged pods and we deploy it in the GPU Add-on namespace, so we can simply update the GPU Add-on namespace labels to allow privileged pods.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>