### PR TITLE
Install gpu operator from addon catalog

### DIFF
--- a/controllers/gpuaddon/defaults.go
+++ b/controllers/gpuaddon/defaults.go
@@ -19,7 +19,7 @@ package gpuaddon
 var (
 	OpenShiftGPUOperatorCompatibilityMatrix = map[string][]string{
 		"4.9": []string{
-			"v1.9",
+			"v1.9.0",
 			"v1.10",
 		},
 		"4.10": []string{

--- a/controllers/gpuaddon/subscription_resource_reconciler.go
+++ b/controllers/gpuaddon/subscription_resource_reconciler.go
@@ -118,7 +118,7 @@ func (r *SubscriptionResourceReconciler) setDesiredSubscription(
 	lastIndex := len(OpenShiftGPUOperatorCompatibilityMatrix[ocpVersion]) - 1
 
 	s.Spec = &operatorsv1alpha1.SubscriptionSpec{
-		CatalogSource:          "certified-operators",
+		CatalogSource:          "addon-nvidia-gpu-addon",
 		CatalogSourceNamespace: "openshift-marketplace",
 		Channel:                OpenShiftGPUOperatorCompatibilityMatrix[ocpVersion][lastIndex],
 		Package:                packageName,


### PR DESCRIPTION
This PR changes the OLM catalog from which the GPU operator subscription is installed from the `certified-operators` to the `addon-nvidia-gpu-addon` one (i.e. the OLM catalog of the NVIDIA GPU Add-on).

It also fixes the channel version for the GPU Operator v1.9, which should be [v1.9.0](https://gitlab.com/nvidia/kubernetes/gpu-operator/-/blob/master/bundle/v1.9.0/metadata/annotations.yaml#L3).