### PR TITLE
Fix gpu-operator-certified subscription catalog name and namespace

### DIFF
--- a/controllers/gpuaddon/subscription_resource_reconciler.go
+++ b/controllers/gpuaddon/subscription_resource_reconciler.go
@@ -118,8 +118,8 @@ func (r *SubscriptionResourceReconciler) setDesiredSubscription(
 	lastIndex := len(OpenShiftGPUOperatorCompatibilityMatrix[ocpVersion]) - 1
 
 	s.Spec = &operatorsv1alpha1.SubscriptionSpec{
-		CatalogSource:          "addon-nvidia-gpu-addon",
-		CatalogSourceNamespace: "openshift-marketplace",
+		CatalogSource:          "addon-nvidia-gpu-addon-catalog",
+		CatalogSourceNamespace: common.GlobalConfig.AddonNamespace,
 		Channel:                OpenShiftGPUOperatorCompatibilityMatrix[ocpVersion][lastIndex],
 		Package:                packageName,
 		InstallPlanApproval:    operatorsv1alpha1.ApprovalAutomatic,


### PR DESCRIPTION
This PR fixes the `gpu-operator-subscription` catalog name and namespace. After testing in an actual OSD cluster the add-on catalog name and namespace are the ones suggested in this PR, i.e. `addon-nvidia-gpu-addon-catalog` and the add-on's namespace (`redhat-nvidia-gpu-addon`).
 
Signed-off-by: Michail Resvanis <mresvani@redhat.com>