### PR TITLE
Fix console cluster plugins getting unnecessarily patched

### DIFF
--- a/controllers/gpuaddon/consoleplugin_resource_reconciler.go
+++ b/controllers/gpuaddon/consoleplugin_resource_reconciler.go
@@ -194,10 +194,14 @@ func (r *ConsolePluginResourceReconciler) patchClusterConsole(
 	}
 
 	patched := console.DeepCopy()
-	patched.Spec.Plugins = append(patched.Spec.Plugins, consolePluginName)
 
-	if err := c.Patch(ctx, patched, client.MergeFrom(console)); err != nil {
-		return err
+	exists := common.SliceContainsString(patched.Spec.Plugins, consolePluginName)
+	if !exists {
+		patched.Spec.Plugins = append(patched.Spec.Plugins, consolePluginName)
+
+		if err := c.Patch(ctx, patched, client.MergeFrom(console)); err != nil {
+			return err
+		}
 	}
 
 	logger.Info("ConsolePlugin Cluster Console reconciled successfully",


### PR DESCRIPTION
This commit fixes the issue of the console cluster CR's plugins array getting patched with the addition of the `console-plugin-nvidia-gpu` name even when it was already part of the array.

Signed-off-by: Michail Resvanis mresvani@redhat.com