### PR TITLE
Set imagePullPolicy to Always for the operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,7 @@ spec:
         - name: RELATED_IMAGE_CONSOLE_PLUGIN
           value: quay.io/edge-infrastructure/console-plugin-nvidia-gpu:latest
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR set the [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) of the add-on operator to `Always`, in order to make sure that we always have the latest digest of the operator image on a cluster.