### PR TITLE
Remove unused SubscriptionInstalled metric labels

### DIFF
--- a/controllers/gpuaddon/metrics.go
+++ b/controllers/gpuaddon/metrics.go
@@ -27,7 +27,7 @@ var (
 			Name: "nvidia_gpuaddon_gpu_operator_subscription_installed",
 			Help: "Reports whether the NVIDIA GPUAddon GPU Operator OLM Subscription is installed",
 		},
-		[]string{"current_csv", "installed_csv"},
+		[]string{},
 	)
 )
 

--- a/controllers/gpuaddon/subscription_resource_reconciler.go
+++ b/controllers/gpuaddon/subscription_resource_reconciler.go
@@ -76,9 +76,9 @@ func (r *SubscriptionResourceReconciler) Reconcile(
 		s = existingSubscription
 
 		if s.Status.InstalledCSV != "" {
-			SubscriptionInstalled.WithLabelValues(s.Status.CurrentCSV, s.Status.InstalledCSV).Set(1)
+			SubscriptionInstalled.WithLabelValues().Set(1)
 		} else {
-			SubscriptionInstalled.WithLabelValues("", "").Set(0)
+			SubscriptionInstalled.WithLabelValues().Set(0)
 		}
 	}
 


### PR DESCRIPTION
This PR removes the unused/unnecessary `NvidiaGpuAddonGpuOperatorSubscriptionInstalled` metric labels.