### PR TITLE
Use console-plugin image tag release-0.0.1 instead of latest

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
         - --leader-elect
         env:
         - name: RELATED_IMAGE_CONSOLE_PLUGIN
-          value: quay.io/edge-infrastructure/console-plugin-nvidia-gpu:latest
+          value: quay.io/edge-infrastructure/console-plugin-nvidia-gpu:release-0.0.1
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/config/manifests/patches/related_images.yaml
+++ b/config/manifests/patches/related_images.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   relatedImages:
     - name: console-plugin
-      image: quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:248080b389af7249389d6d29c6683127b92932f2d6439f7474b3886b08773860
+      image: quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:cec17462944cb2f800e7477101e0470c5f7a07998c012ef7470e14993ebebf40

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -42,7 +42,7 @@ type config struct {
 	NfdCrName string `envconfig:"NFD_CR_NAME" default:"ocp-gpu-addon"`
 
 	// RELATED_IMAGE_PLUGIN_IMAGE
-	ConsolePluginImage string `envconfig:"RELATED_IMAGE_CONSOLE_PLUGIN" default:"quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:248080b389af7249389d6d29c6683127b92932f2d6439f7474b3886b08773860"`
+	ConsolePluginImage string `envconfig:"RELATED_IMAGE_CONSOLE_PLUGIN" default:"quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:cec17462944cb2f800e7477101e0470c5f7a07998c012ef7470e14993ebebf40"`
 
 	// PAGER_DUTY_SECRET_NAME
 	PagerDutySecretName string `envconfig:"PAGER_DUTY_SECRET_NAME" default:"pagerduty"`


### PR DESCRIPTION
This PR replaces the default [console-plugin-nvidia-gpu](https://github.com/rh-ecosystem-edge/console-plugin-nvidia-gpu) image tag `latest` to `release-0.0.1`. According to the [compatibility matrix](https://quay.io/repository/edge-infrastructure/console-plugin-nvidia-gpu?tab=tags) of the `console-plugin-nvidia-gpu`, `latest` is compatible with OCP `4.11+`, whereas `release-0.0.1` is compatible with OCP `4.10+`. 

> The console-plugin-nvidia-gpu image repository is hosted [here](https://quay.io/repository/edge-infrastructure/console-plugin-nvidia-gpu?tab=tags).

Signed-off-by: Michail Resvanis <mresvani@redhat.com>