### PR TITLE
Add NFD image to related images and use v4.10 tag by default

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,8 @@ spec:
         env:
         - name: RELATED_IMAGE_CONSOLE_PLUGIN
           value: quay.io/edge-infrastructure/console-plugin-nvidia-gpu:release-0.0.1
+        - name: RELATED_IMAGE_NODE_FEATURE_DISCOVERY
+          value: registry.access.redhat.com/openshift4/ose-node-feature-discovery:v4.10
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/controllers/gpuaddon/nfd_resource_reconciler.go
+++ b/controllers/gpuaddon/nfd_resource_reconciler.go
@@ -109,15 +109,10 @@ func (r *NFDResourceReconciler) setDesiredNFD(
 		return errors.New("nfd cannot be nil")
 	}
 
-	ocpVersion, err := common.GetOpenShiftVersion(client)
-	if err != nil {
-		return err
-	}
-
 	nfd.Spec = nfdv1.NodeFeatureDiscoverySpec{}
 
 	nfd.Spec.Operand = nfdv1.OperandSpec{
-		Image:           fmt.Sprintf("registry.redhat.io/openshift4/ose-node-feature-discovery:v%s", ocpVersion),
+		Image:           common.GlobalConfig.NodeFeatureDiscoveryImage,
 		ImagePullPolicy: "Always",
 		ServicePort:     12000,
 	}

--- a/controllers/gpuaddon/nfd_resource_reconciler_test.go
+++ b/controllers/gpuaddon/nfd_resource_reconciler_test.go
@@ -19,7 +19,6 @@ package gpuaddon
 import (
 	"context"
 
-	configv1 "github.com/openshift/api/config/v1"
 	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/scheme"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -44,23 +43,9 @@ var _ = Describe("NFD Resource Reconcile", Ordered, func() {
 				Namespace: "test",
 			},
 		}
-		clusterVersion := &configv1.ClusterVersion{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "version",
-			},
-			Status: configv1.ClusterVersionStatus{
-				History: []configv1.UpdateHistory{
-					{
-						State:   configv1.CompletedUpdate,
-						Version: "4.9.7",
-					},
-				},
-			},
-		}
 
 		scheme := scheme.Scheme
 		Expect(nfdv1.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-		Expect(configv1.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 
 		var nfd nfdv1.NodeFeatureDiscovery
 
@@ -68,7 +53,7 @@ var _ = Describe("NFD Resource Reconcile", Ordered, func() {
 			c := fake.
 				NewClientBuilder().
 				WithScheme(scheme).
-				WithRuntimeObjects(clusterVersion).
+				WithRuntimeObjects().
 				Build()
 
 			cond, err := rrec.Reconcile(context.TODO(), c, &gpuAddon)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -44,6 +44,9 @@ type config struct {
 	// RELATED_IMAGE_PLUGIN_IMAGE
 	ConsolePluginImage string `envconfig:"RELATED_IMAGE_CONSOLE_PLUGIN" default:"quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:cec17462944cb2f800e7477101e0470c5f7a07998c012ef7470e14993ebebf40"`
 
+	// RELATED_IMAGE_NODE_FEATURE_DISCOVERY
+	NodeFeatureDiscoveryImage string `envconfig:"RELATED_IMAGE_NODE_FEATURE_DISCOVERY" default:"registry.access.redhat.com/openshift4/ose-node-feature-discovery@sha256:07658ef3df4b264b02396e67af813a52ba416b47ab6e1d2d08025a350ccd2b7b"`
+
 	// PAGER_DUTY_SECRET_NAME
 	PagerDutySecretName string `envconfig:"PAGER_DUTY_SECRET_NAME" default:"pagerduty"`
 


### PR DESCRIPTION
This PR adds the [NFD image](https://catalog.redhat.com/software/containers/openshift4/ose-node-feature-discovery/5d96f167d70cc50ebeaadb9c?container-tabs=gti&gti-tabs=registry-tokens) to the add-on operator's [related images](https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs) and at the same time ensures that the `v4.10` tag of this image is used by default (and not a tag that depends on the OCP version).