### PR TITLE
Adjust related images

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -25,6 +25,3 @@ resources:
 #    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
 #    - op: remove
 #      path: /spec/template/spec/volumes/0
-
-patchesStrategicMerge:
-- patches/related_images.yaml

--- a/config/manifests/patches/related_images.yaml
+++ b/config/manifests/patches/related_images.yaml
@@ -1,9 +1,0 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: ClusterServiceVersion
-metadata:
-  name: nvidia-gpu-addon-operator.v99.0.0
-  namespace: placeholder
-spec:
-  relatedImages:
-    - name: console-plugin
-      image: quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:cec17462944cb2f800e7477101e0470c5f7a07998c012ef7470e14993ebebf40


### PR DESCRIPTION
This PR removes the unnecessary kustomize patch of the `relatedImages` field, because we are already using the respective [related images environment variables](https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs).

To generate the bundle, we can use the following command, in order to have the `relatedImages` added correctly to the main CSV:

```shell
# generate the bundle
$ make bundle USE_IMAGE_DIGESTS=true

# in the generated bundle you will find the following relatedImages field
$ cat bundle/manifests/nvidia-gpu-addon-operator.clusterserviceversion.yaml |grep -A6 relatedImages
  relatedImages:
    - image: quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:cec17462944cb2f800e7477101e0470c5f7a07998c012ef7470e14993ebebf40
      name: console-plugin
    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c
      name: kube-rbac-proxy
    - image: quay.io/mresvani/nvidia-gpu-addon-operator@sha256:d4343233dbf81700c9358f9ef0477895994f31abfdc4cb6e46a38ed0facb2376
      name: manager
```

And to make it more convenient:

```shell
$ make mtb-bundle mP=~/addons/managed-tenants-bundles v=1.0.0 c=beta USE_IMAGE_DIGESTS=true
```