### PR TITLE
Use default NFD operand image provided by the NFD operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,8 +35,6 @@ spec:
         env:
         - name: RELATED_IMAGE_CONSOLE_PLUGIN
           value: quay.io/edge-infrastructure/console-plugin-nvidia-gpu:release-0.0.1
-        - name: RELATED_IMAGE_NODE_FEATURE_DISCOVERY
-          value: registry.access.redhat.com/openshift4/ose-node-feature-discovery:v4.10
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/controllers/gpuaddon/nfd_resource_reconciler.go
+++ b/controllers/gpuaddon/nfd_resource_reconciler.go
@@ -112,7 +112,6 @@ func (r *NFDResourceReconciler) setDesiredNFD(
 	nfd.Spec = nfdv1.NodeFeatureDiscoverySpec{}
 
 	nfd.Spec.Operand = nfdv1.OperandSpec{
-		Image:           common.GlobalConfig.NodeFeatureDiscoveryImage,
 		ImagePullPolicy: "Always",
 		ServicePort:     12000,
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -44,9 +44,6 @@ type config struct {
 	// RELATED_IMAGE_PLUGIN_IMAGE
 	ConsolePluginImage string `envconfig:"RELATED_IMAGE_CONSOLE_PLUGIN" default:"quay.io/edge-infrastructure/console-plugin-nvidia-gpu@sha256:cec17462944cb2f800e7477101e0470c5f7a07998c012ef7470e14993ebebf40"`
 
-	// RELATED_IMAGE_NODE_FEATURE_DISCOVERY
-	NodeFeatureDiscoveryImage string `envconfig:"RELATED_IMAGE_NODE_FEATURE_DISCOVERY" default:"registry.access.redhat.com/openshift4/ose-node-feature-discovery@sha256:07658ef3df4b264b02396e67af813a52ba416b47ab6e1d2d08025a350ccd2b7b"`
-
 	// PAGER_DUTY_SECRET_NAME
 	PagerDutySecretName string `envconfig:"PAGER_DUTY_SECRET_NAME" default:"pagerduty"`
 


### PR DESCRIPTION
This PR removes the definition of the NFD operand image and leaves the latter to be defined by the NFD operator. 

Signed-off-by: Michail Resvanis <mresvani@redhat.com>