### PR TITLE
Add app label to prometheus CRs and use it as a selector

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
+    app: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -24,6 +25,7 @@ kind: PrometheusRule
 metadata:
   labels:
     control-plane: controller-manager
+    app: controller-manager
   name: controller-manager-metrics
   namespace: system
 spec:

--- a/controllers/monitoring/prometheus.go
+++ b/controllers/monitoring/prometheus.go
@@ -87,21 +87,21 @@ func (r *MonitoringReconciler) setDesiredPrometheus(
 		return errors.New("prometheus cannot be nil")
 	}
 
-	resourceSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"control-plane": "controller-manager",
+	selector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "app", Operator: metav1.LabelSelectorOpExists},
 		},
 	}
 
 	prometheus.Spec = promv1.PrometheusSpec{
 		CommonPrometheusFields: promv1.CommonPrometheusFields{
 			ServiceAccountName:     "prometheus-k8s",
-			ServiceMonitorSelector: &resourceSelector,
-			PodMonitorSelector:     &resourceSelector,
+			ServiceMonitorSelector: &selector,
+			PodMonitorSelector:     &selector,
 			EnableAdminAPI:         false,
 			ListenLocal:            true,
 		},
-		RuleSelector: &resourceSelector,
+		RuleNamespaceSelector: &selector,
 	}
 
 	prometheus.Spec.Alerting = &promv1.AlertingSpec{


### PR DESCRIPTION
This PR adds the `app` label to all prometheus-operator CRs, in order to check for its existence in the respective Prometheus CR {Pod,Service}MonitorSelector and RuleSelector (which are `metav1.LabelSelector`s that do not support `OR`-ed expressions). That way the Prometheus scrape configuration will include all monitors that have this label. 

### Context
The Prometheus CR needs a LabelSelector to add `{Pod,Service}Monitor`s and `Rule`s in its configuration. `metav1LabelSelector`s do not support `OR`-ed expressions, only `AND`-ed ones, which is the reason to have a common label among all prometheus CRs. Then we simply check for this label's existence. This change is driven by the fact that the GPU operator adds the `app` label to all of its prometheus-operator CRs.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>