### PR TITLE
Replace OLM pkg dep name nfd with ose-nfd

### DIFF
--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - type: olm.package
   value:
-    packageName: nfd
+    packageName: ose-nfd
     version: "4.10.0"
 - type: olm.package
   value:


### PR DESCRIPTION
This PR replaces the OLM dependency package name of `nfd` to `ose-nfd`. This change is temporary until the NFD OLM OLM resolution issue, which was leading to the GPU operator taking randomly too much time to be installed (if at all), is resolved.

- https://bugzilla.redhat.com/show_bug.cgi?id=2083755

Signed-off-by: Michail Resvanis <mresvani@redhat.com>