### PR TITLE
Fix ConfigMapReconciler not deleting the GPUAddon CR

### DIFF
--- a/controllers/configmap/configmap_controller_test.go
+++ b/controllers/configmap/configmap_controller_test.go
@@ -4,83 +4,86 @@ import (
 	"context"
 
 	gpuv1 "github.com/NVIDIA/gpu-operator/api/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/scheme"
-	addonv1alpha1 "github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/api/v1alpha1"
-	"github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/internal/common"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	addonv1alpha1 "github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/api/v1alpha1"
+	"github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/internal/common"
 )
 
-var _ = Describe("ConfigMap Controller Tests", func() {
-	It("deleteGouAddon function test", func() {
-		gpuaddon := &addonv1alpha1.GPUAddon{}
-		gpuaddon.Name = "TestAddon"
-		gpuaddon.Namespace = common.GlobalConfig.AddonNamespace
+var _ = Describe("ConfigMapReconciler", func() {
+	Describe("Reconcile", func() {
+		common.ProcessConfig()
 
-		g := &addonv1alpha1.GPUAddon{}
-		reconciler := newTestConfigReconciler(gpuaddon)
+		configmap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.GlobalConfig.AddonID,
+				Namespace: common.GlobalConfig.AddonNamespace,
+			},
+		}
 
-		err := reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "TestAddon", Namespace: gpuaddon.Namespace}, g)
-		Expect(err).ShouldNot(HaveOccurred())
+		gpuaddon := &addonv1alpha1.GPUAddon{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "TestAddon",
+				Namespace: common.GlobalConfig.AddonNamespace,
+			},
+		}
 
-		err = reconciler.deleteGpuAddonCr(context.TODO(), gpuaddon.Namespace)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: "TestAddon", Namespace: gpuaddon.Namespace}, g)
-		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-	})
-	Context("Reconcile tests", func() {
-		configmap := &v1.ConfigMap{}
-		configmap.Name = common.GlobalConfig.AddonID
-		configmap.Namespace = common.GlobalConfig.AddonNamespace
-		configmap.Labels = map[string]string{}
-
-		gpuaddon := &addonv1alpha1.GPUAddon{}
-		gpuaddon.Name = "TestAddon"
-		gpuaddon.Namespace = configmap.Namespace
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      common.GlobalConfig.AddonID,
 				Namespace: common.GlobalConfig.AddonNamespace,
 			},
 		}
+
 		g := &addonv1alpha1.GPUAddon{}
-		It("Happy flow", func() {
-			// Delete Addon CR
-			configmap.Labels[AddonDeleteLabel] = "true"
 
-			r := newTestConfigReconciler(configmap, gpuaddon)
+		Context("with a valid configmap label", func() {
+			BeforeEach(func() {
+				configmap.Labels = map[string]string{
+					getAddonDeleteLabel(): "true",
+				}
+			})
 
-			_, err := r.Reconcile(context.TODO(), req)
-			Expect(err).ShouldNot(HaveOccurred())
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "TestAddon", Namespace: configmap.Namespace}, g)
-			Expect(err).Should(HaveOccurred())
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			It("should delete the GPUAddon CR", func() {
+				r := newTestConfigReconciler(configmap, gpuaddon)
 
+				_, err := r.Reconcile(context.TODO(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = r.Get(context.TODO(), types.NamespacedName{Name: gpuaddon.Name, Namespace: gpuaddon.Namespace}, g)
+				Expect(err).Should(HaveOccurred())
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
 		})
 
-		It("Should not do anything when no delete label, or invalid value", func() {
-			configmap.Labels = map[string]string{}
-			r := newTestConfigReconciler(configmap, gpuaddon)
-			// Dont return error and ignore when invalid value or non relevant configmap
-			_, err := r.Reconcile(context.TODO(), req)
-			Expect(err).ShouldNot(HaveOccurred())
+		Context("with an invalid configmap label", func() {
+			BeforeEach(func() {
+				configmap.Labels = map[string]string{
+					getAddonDeleteLabel(): "invalidBool",
+				}
+			})
 
-			configmap.Labels[AddonDeleteLabel] = "invalidBool"
-			_, err = r.Reconcile(context.TODO(), req)
-			Expect(err).ShouldNot(HaveOccurred())
+			It("should not do anything", func() {
+				r := newTestConfigReconciler(configmap, gpuaddon)
 
-			// GPU addon should still exists
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "TestAddon", Namespace: configmap.Namespace}, g)
-			Expect(err).ShouldNot(HaveOccurred())
+				_, err := r.Reconcile(context.TODO(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = r.Client.Get(context.TODO(), types.NamespacedName{Name: gpuaddon.Name, Namespace: gpuaddon.Namespace}, g)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
 		})
 	})
 })
@@ -89,7 +92,7 @@ func newTestConfigReconciler(objs ...runtime.Object) *ConfigMapReconciler {
 	s := scheme.Scheme
 
 	Expect(operatorsv1alpha1.AddToScheme(s)).ShouldNot(HaveOccurred())
-	Expect(v1.AddToScheme(s)).ShouldNot(HaveOccurred())
+	Expect(corev1.AddToScheme(s)).ShouldNot(HaveOccurred())
 	Expect(addonv1alpha1.AddToScheme(s)).ShouldNot(HaveOccurred())
 	Expect(gpuv1.AddToScheme(s)).ShouldNot(HaveOccurred())
 	Expect(nfdv1.AddToScheme(s)).ShouldNot(HaveOccurred())


### PR DESCRIPTION
This PR fixes the `ConfigMap` reconciler not deleting the `GPUAddon` CR, when OCM applies the deletion `configmap` to the add-on namespace. According to the respective [docs](https://gitlab.cee.redhat.com/service/managed-tenants/-/blob/main/docs/ocm/addons_external_resources.md#addon-deletion). 

Signed-off-by: Michail Resvanis <mresvani@redhat.com>