### PR TITLE
Delete GPUAddon CR when Deletion ConfigMap gets deleted

### DIFF
--- a/controllers/configmap/configmap_controller_test.go
+++ b/controllers/configmap/configmap_controller_test.go
@@ -50,12 +50,6 @@ var _ = Describe("ConfigMapReconciler", func() {
 		g := &addonv1alpha1.GPUAddon{}
 
 		Context("with a valid configmap label", func() {
-			BeforeEach(func() {
-				configmap.Labels = map[string]string{
-					getAddonDeleteLabel(): "true",
-				}
-			})
-
 			It("should delete the GPUAddon CR", func() {
 				r := newTestConfigReconciler(configmap, gpuaddon)
 
@@ -65,24 +59,6 @@ var _ = Describe("ConfigMapReconciler", func() {
 				err = r.Get(context.TODO(), types.NamespacedName{Name: gpuaddon.Name, Namespace: gpuaddon.Namespace}, g)
 				Expect(err).Should(HaveOccurred())
 				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-			})
-		})
-
-		Context("with an invalid configmap label", func() {
-			BeforeEach(func() {
-				configmap.Labels = map[string]string{
-					getAddonDeleteLabel(): "invalidBool",
-				}
-			})
-
-			It("should not do anything", func() {
-				r := newTestConfigReconciler(configmap, gpuaddon)
-
-				_, err := r.Reconcile(context.TODO(), req)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				err = r.Client.Get(context.TODO(), types.NamespacedName{Name: gpuaddon.Name, Namespace: gpuaddon.Namespace}, g)
-				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
 	})

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -32,9 +32,6 @@ type config struct {
 	// ADDON_ID
 	AddonID string `envconfig:"ADDON_ID" default:"nvidia-gpu-addon"`
 
-	// ADDON_LABEL
-	AddonLabel string `envconfig:"ADDON_LABEL" default:"api.openshift.com/addon-nvidia-gpu-addon"`
-
 	// CLUSTER_POLICY_NAME
 	ClusterPolicyName string `envconfig:"CLUSTER_POLICY_NAME" default:"ocp-gpu-addon"`
 

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func jumpstartAddon(client client.Client) error {
 	}
 
 	result, err := controllerutil.CreateOrPatch(context.TODO(), client, gpuAddon, func() error {
-		versionLabel := fmt.Sprintf("%v-version", common.GlobalConfig.AddonLabel)
+		versionLabel := fmt.Sprintf("%v-version", common.GlobalConfig.AddonID)
 		gpuAddon.ObjectMeta.Labels = map[string]string{
 			versionLabel: version.Version(),
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Jumpstart GPUAddon", func() {
 			Namespace: common.GlobalConfig.AddonNamespace,
 			Name:      common.GlobalConfig.AddonID,
 		}, g)).ShouldNot(HaveOccurred())
-		versionLabel := fmt.Sprintf("%v-version", common.GlobalConfig.AddonLabel)
+		versionLabel := fmt.Sprintf("%v-version", common.GlobalConfig.AddonID)
 		Expect(g.ObjectMeta.Labels[versionLabel]).To(Equal(version.Version()))
 	})
 })


### PR DESCRIPTION
According to the respective documentation:

> NOTE: A label will be added to add-on namespace
{{ADDON.metadata['label']}}-delete: 'true' on addon deletion.
This is deprecated, add-ons should watch for delete ConfigMap
to trigger resource clean up.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>