### PR TITLE
Revert cleanup with OCM ConfigMap creation instead of deletion

### DIFF
--- a/controllers/configmap/configmap_controller.go
+++ b/controllers/configmap/configmap_controller.go
@@ -88,13 +88,13 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func configMapFilter() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return false
+			return isAddonConfigMap(e.ObjectNew)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return false
+			return isAddonConfigMap(e.Object)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isAddonConfigMap(e.Object)
+			return false
 		},
 	}
 }


### PR DESCRIPTION
This PR changes the behaviour set by this [PR](https://github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/pull/65) to watch for the creation of the OCM Deletion ConfigMap, instead of its `Deletion`. We should have just skipped the label check.
 
Signed-off-by: Michail Resvanis <mresvani@redhat.com>