### PR TITLE
MGMT-9658 add NVAIe support

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -86,8 +86,10 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/controllers/gpuaddon/gpuaddon_controller.go
+++ b/controllers/gpuaddon/gpuaddon_controller.go
@@ -72,6 +72,7 @@ var resourceOrderedReconcilers = []ResourceReconciler{
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",namespace=system,resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/gpuaddon/gpuaddon_controller.go
+++ b/controllers/gpuaddon/gpuaddon_controller.go
@@ -54,6 +54,7 @@ type GPUAddonReconciler struct {
 
 // List of other resources managed by this operator.
 var resourceOrderedReconcilers = []ResourceReconciler{
+	&NGCSecretResourceReconciler{},
 	&NFDResourceReconciler{},
 	&SubscriptionResourceReconciler{},
 	&ClusterPolicyResourceReconciler{},
@@ -140,6 +141,7 @@ func (r *GPUAddonReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Cont
 		Owns(&consolev1alpha1.ConsolePlugin{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&corev1.Secret{}).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(getGpuAddonFromAddonParametersSecret),

--- a/controllers/gpuaddon/ngcsecret_resource_reconciler.go
+++ b/controllers/gpuaddon/ngcsecret_resource_reconciler.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpuaddon
+
+import (
+	"context"
+	b64 "encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	addonv1alpha1 "github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/api/v1alpha1"
+	"github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/internal/common"
+)
+
+const (
+	NGCSecretDeployedCondition = "NGCSecretDeployed"
+
+	secretName = "ngc-secret"
+
+	addonParametersSecretName = "addon-nvidia-gpu-addon-parameters"
+
+	// https://gitlab.com/nvidia/kubernetes/gpu-operator/-/blob/master/scripts/install-gpu-operator-nvaie.sh#L44
+	dockerServer   = "nvcr.io"
+	dockerUsername = "$oauthtoken"
+
+	// https://gitlab.cee.redhat.com/service/managed-tenants/-/blob/main/docs/ocm/addon_parameters.md#accessing-parameter-values
+	ngcAPIKeyParamName = "ngc-api-key"
+	ngcEmailParamName  = "ngc-email"
+)
+
+type NGCSecretResourceReconciler struct{}
+
+var _ ResourceReconciler = &NGCSecretResourceReconciler{}
+
+func (r *NGCSecretResourceReconciler) Reconcile(
+	ctx context.Context,
+	client client.Client,
+	gpuAddon *addonv1alpha1.GPUAddon) ([]metav1.Condition, error) {
+
+	logger := log.FromContext(ctx, "Reconcile Step", "NGC Secret")
+	conditions := []metav1.Condition{}
+
+	addonParametersSecret := &corev1.Secret{}
+
+	err := client.Get(ctx, types.NamespacedName{
+		Namespace: gpuAddon.Namespace,
+		Name:      addonParametersSecretName,
+	}, addonParametersSecret)
+
+	exists := !k8serrors.IsNotFound(err)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		conditions = append(conditions, r.getDeployedConditionFetchParametersFailed())
+		return conditions, err
+	}
+
+	if !exists {
+		conditions = append(conditions, r.getDeployedConditionParametersNotPresent())
+
+		logger.Info("NGC secret will not be reconciled as the add-on parameters secret is not present",
+			"NGC secret name", secretName,
+			"add-on parameters secret", addonParametersSecretName,
+			"namespace", gpuAddon.Namespace)
+
+		return conditions, nil
+	}
+
+	if isValid, err := r.isAddonParametersSecretValid(addonParametersSecret); !isValid {
+		conditions = append(conditions, r.getDeployedConditionParametersNotValid())
+
+		logger.Info("NGC secret will not be reconciled as the add-on parameters secret is invalid",
+			"NGC secret name", secretName,
+			"add-on parameters secret", addonParametersSecretName,
+			"namespace", gpuAddon.Namespace,
+			"error", err)
+
+		return conditions, nil
+	}
+
+	existingSecret := &corev1.Secret{}
+
+	err = client.Get(ctx, types.NamespacedName{
+		Namespace: gpuAddon.Namespace,
+		Name:      secretName,
+	}, existingSecret)
+
+	exists = !k8serrors.IsNotFound(err)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		conditions = append(conditions, r.getDeployedConditionFetchFailed())
+		return conditions, err
+	}
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: gpuAddon.Namespace,
+			Name:      secretName,
+		},
+		Type: "kubernetes.io/dockerconfigjson",
+	}
+
+	if exists {
+		s = existingSecret
+	}
+
+	res, err := controllerutil.CreateOrPatch(context.TODO(), client, s, func() error {
+		return r.setDesiredNGCSecret(client, s, addonParametersSecret, gpuAddon)
+	})
+
+	if err != nil {
+		conditions = append(conditions, r.getDeployedConditionCreateFailed())
+		return conditions, err
+	}
+
+	conditions = append(conditions, r.getDeployedConditionCreateSuccess())
+
+	logger.Info("NGC secret reconciled successfully",
+		"name", s.Name,
+		"namespace", s.Namespace,
+		"result", res)
+
+	return conditions, nil
+}
+
+func (r *NGCSecretResourceReconciler) setDesiredNGCSecret(
+	client client.Client,
+	s *corev1.Secret,
+	addonParametersSecret *corev1.Secret,
+	gpuAddon *addonv1alpha1.GPUAddon) error {
+
+	if s == nil {
+		return errors.New("secret cannot be nil")
+	}
+
+	if addonParametersSecret == nil {
+		return errors.New("addon parameters secret cannot be nil")
+	}
+
+	password := string(addonParametersSecret.Data[ngcAPIKeyParamName])
+	email := string(addonParametersSecret.Data[ngcEmailParamName])
+	auth := b64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", dockerUsername, password)))
+
+	dockerconfig := map[string]map[string]map[string]string{
+		"auths": map[string]map[string]string{
+			dockerServer: map[string]string{
+				"username": dockerUsername,
+				"password": password,
+				"email":    email,
+				"auth":     auth,
+			},
+		},
+	}
+	dockerconfigjson, err := json.Marshal(dockerconfig)
+	if err != nil {
+		return err
+	}
+
+	s.ObjectMeta = metav1.ObjectMeta{
+		Name:      s.Name,
+		Namespace: s.Namespace,
+	}
+	s.StringData = map[string]string{".dockerconfigjson": string(dockerconfigjson)}
+
+	return ctrl.SetControllerReference(gpuAddon, s, client.Scheme())
+}
+
+func (r *NGCSecretResourceReconciler) Delete(ctx context.Context, c client.Client) (bool, error) {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: common.GlobalConfig.AddonNamespace,
+			Name:      secretName,
+		},
+	}
+
+	if err := c.Delete(ctx, s); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to delete secret %s: %w", s.Name, err)
+	}
+
+	return true, nil
+}
+
+func (r *NGCSecretResourceReconciler) getDeployedConditionParametersNotPresent() metav1.Condition {
+	return common.NewCondition(
+		NGCSecretDeployedCondition,
+		metav1.ConditionTrue,
+		"AddonParametersSecretNotPresent",
+		"Add-on parameters secret is not present")
+}
+
+func (r *NGCSecretResourceReconciler) getDeployedConditionParametersNotValid() metav1.Condition {
+	return common.NewCondition(
+		NGCSecretDeployedCondition,
+		metav1.ConditionTrue,
+		"AddonParametersSecretNotValid",
+		"Add-on parameters secret contains invalid parameters")
+}
+
+func (r *NGCSecretResourceReconciler) getDeployedConditionFetchParametersFailed() metav1.Condition {
+	return common.NewCondition(
+		NGCSecretDeployedCondition,
+		metav1.ConditionTrue,
+		"FetchAddonParametersFailed",
+		"Failed to fetch add-on parameters Secret")
+}
+
+func (r *NGCSecretResourceReconciler) getDeployedConditionFetchFailed() metav1.Condition {
+	return common.NewCondition(
+		NGCSecretDeployedCondition,
+		metav1.ConditionTrue,
+		"FetchSecretFailed",
+		"Failed to fetch NGC Secret")
+}
+
+func (r *NGCSecretResourceReconciler) getDeployedConditionCreateFailed() metav1.Condition {
+	return common.NewCondition(
+		SubscriptionDeployedCondition,
+		metav1.ConditionTrue,
+		"CreateSecretFailed",
+		"Failed to create NGC Secret")
+}
+
+func (r *NGCSecretResourceReconciler) getDeployedConditionCreateSuccess() metav1.Condition {
+	return common.NewCondition(
+		NGCSecretDeployedCondition,
+		metav1.ConditionTrue,
+		"CreateSecretSuccess",
+		"NGC Secret deployed successfully")
+}
+
+func (r *NGCSecretResourceReconciler) isAddonParametersSecretValid(aps *corev1.Secret) (bool, error) {
+	ngcEmail := aps.Data[ngcEmailParamName]
+	if len(ngcEmail) <= 0 {
+		return false, fmt.Errorf("%s parameter is not present", ngcEmailParamName)
+	}
+
+	ngcAPIKey := aps.Data[ngcAPIKeyParamName]
+	if len(ngcAPIKey) <= 0 {
+		return false, fmt.Errorf("%s parameter is not present", ngcAPIKeyParamName)
+	}
+
+	return true, nil
+}

--- a/controllers/gpuaddon/ngcsecret_resource_reconciler_test.go
+++ b/controllers/gpuaddon/ngcsecret_resource_reconciler_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpuaddon
+
+import (
+	"context"
+
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/scheme"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	addonv1alpha1 "github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/api/v1alpha1"
+	"github.com/rh-ecosystem-edge/nvidia-gpu-addon-operator/internal/common"
+)
+
+var _ = Describe("NGC Secret Resource Reconcile", Ordered, func() {
+	Context("Reconcile", func() {
+		common.ProcessConfig()
+		rrec := &NGCSecretResourceReconciler{}
+		gpuAddon := addonv1alpha1.GPUAddon{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: common.GlobalConfig.AddonNamespace,
+			},
+		}
+
+		scheme := scheme.Scheme
+
+		var s corev1.Secret
+
+		Context("when the addonParametersSecret is present", func() {
+			Context("and contains valid parameters", func() {
+				addonParametersSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "addon-nvidia-gpu-addon-parameters",
+						Namespace: common.GlobalConfig.AddonNamespace,
+					},
+					Data: map[string][]byte{
+						"ngc-api-key": []byte("a-key"),
+						"ngc-email":   []byte("an-email"),
+					},
+				}
+
+				It("should create the NGC Secret", func() {
+					c := fake.
+						NewClientBuilder().
+						WithScheme(scheme).
+						WithRuntimeObjects(addonParametersSecret).
+						Build()
+
+					_, err := rrec.Reconcile(context.TODO(), c, &gpuAddon)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					err = c.Get(context.TODO(), types.NamespacedName{
+						Namespace: gpuAddon.Namespace,
+						Name:      secretName,
+					}, &s)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+
+			Context("and contains invalid parameters", func() {
+				invalidAddonParametersSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "addon-nvidia-gpu-addon-parameters",
+						Namespace: common.GlobalConfig.AddonNamespace,
+					},
+					Data: map[string][]byte{
+						"ngc-email": []byte("an-email"),
+					},
+				}
+
+				It("should not create the NGC Secret", func() {
+					c := fake.
+						NewClientBuilder().
+						WithScheme(scheme).
+						WithRuntimeObjects(invalidAddonParametersSecret).
+						Build()
+
+					_, err := rrec.Reconcile(context.TODO(), c, &gpuAddon)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					err = c.Get(context.TODO(), types.NamespacedName{
+						Namespace: gpuAddon.Namespace,
+						Name:      secretName,
+					}, &s)
+					Expect(err).Should(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when the addonParametersSecret is not present", func() {
+			It("should not create the NGC Secret", func() {
+				c := fake.
+					NewClientBuilder().
+					WithScheme(scheme).
+					WithRuntimeObjects().
+					Build()
+
+				_, err := rrec.Reconcile(context.TODO(), c, &gpuAddon)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = c.Get(context.TODO(), types.NamespacedName{
+					Namespace: gpuAddon.Namespace,
+					Name:      secretName,
+				}, &s)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+
+	Context("Delete", func() {
+		common.ProcessConfig()
+		rrec := &NGCSecretResourceReconciler{}
+
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: common.GlobalConfig.AddonNamespace,
+				Name:      secretName,
+			},
+		}
+
+		scheme := scheme.Scheme
+
+		It("should delete the NGC Secret", func() {
+			c := fake.
+				NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(s).
+				Build()
+
+			deleted, err := rrec.Delete(context.TODO(), c)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(deleted).To(BeTrue())
+
+			err = c.Get(context.TODO(), types.NamespacedName{
+				Namespace: s.Namespace,
+				Name:      s.Name,
+			}, s)
+			Expect(err).Should(HaveOccurred())
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
This PR adds support for [NVAIe](https://www.nvidia.com/en-us/data-center/products/ai-enterprise/). Specifically, it allows users to define their `NGC_API_KEY` during the add-on's installation and get access to the [NVIDIA AI Enterprise Catalog](https://www.nvidia.com/en-us/data-center/products/ai-enterprise/).

## Context

Add-ons can be configured to define [parameters](https://gitlab.cee.redhat.com/service/managed-tenants/-/blob/main/docs/ocm/addon_parameters.md), which are set during the add-on installation via the respective UI form. 

In order to use NVIDIA AI Enterprise Catalog container images (i.e. container images under the namespace `nvcr.io/nvaie`), a pull secret is needed, which contains the user's `NGC API key` and `NGC email`. This secret is created in the add-on namespace if the respective add-on parameters are present.

## Implementation

2 optional add-on parameters are defined (either both should be defined or none):

* `ngc-email`
* `ngc-api-key` 

The flow is as follows:

1 . the `GPUAddon` controller watches for {create,update,delete}s on the OCM created `addon-nvidia-gpu-addon-parameters` secret 
2. if the latter is found, it's fetched, validated (only very basic validation is currently implemented, i.e. existence of the required fields and their length > 0) and the `ngc-secret` secret is reconciled (it contains a `kubernetes.io/.dockerconfigjson` secret with the credentials found in the `addon-nvidia-gpu-addon-parameters` secret)
3. the user can then use the `ngc-secret` in the `imagePullSecret` to run their desired workload based on the NVAIe catalog container images

> if the `addon-nvidia-gpu-addon-parameters` secret is not found or invalid (i.e. it does not contain the required params or those params are empty), then the `ngc-secret` is not reconciled 